### PR TITLE
Fix MusicCard usage and adjust motion imports

### DIFF
--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -1,5 +1,5 @@
 import Navbar from "./components/Navbar.jsx";
-import { motion } from "framer-motion";
+import { motion as Motion } from "framer-motion";
 import arrow2Url from "/arrow-2.svg";
 import arrowUrl from "/arrow.svg";
 import arrow3Url from "/arrow-3.svg";
@@ -24,7 +24,7 @@ export default function Home() {
       <main className="pt-16">
         {/* Hero or intro */}
         <section className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-white text-gray-800">
-          <motion.div
+          <Motion.div
             className="flex w-full max-w-6xl items-center justify-between px-8"
             initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
@@ -70,12 +70,12 @@ export default function Home() {
                 className="h-64 w-64 rounded-4xl object-cover shadow-lg transition-shadow duration-300 hover:scale-101 hover:shadow-2xl hover:shadow-orange-500"
               />
             </div>
-          </motion.div>
+          </Motion.div>
         </section>
 
         {/* Project section */}
         <section className="flex min-h-auto flex-col items-center justify-center bg-gray-50">
-          <motion.div
+          <Motion.div
             className="flex w-full flex-col items-center"
             initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
@@ -128,12 +128,12 @@ export default function Home() {
                 See More Projects
               </a>
             </div>
-          </motion.div>
+          </Motion.div>
         </section>
 
         {/* Music section */}
         <section className="flex min-h-150 items-center justify-center border-12 border-white bg-gray-50">
-          <motion.div
+          <Motion.div
             className="flex w-full max-w-6xl items-center justify-between px-8"
             initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
@@ -178,7 +178,7 @@ export default function Home() {
                 See More Music
               </a>
             </div>
-          </motion.div>
+          </Motion.div>
         </section>
 
         {/* Contact section */}

--- a/src/Music.jsx
+++ b/src/Music.jsx
@@ -1,10 +1,8 @@
 import Navbar from "./components/Navbar.jsx";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion as Motion, AnimatePresence } from "framer-motion";
 import MusicCard from "./components/MusicCard.jsx";
 import monopolyUrl from "/mini-monopoly.jpg";
 import strideUrl from "/stride.svg";
-import reseatUrl from "/reseat.svg";
-import lara1Url from "/lara-1.jpg";
 import { useState } from "react";
 
 const allProjects = [
@@ -50,7 +48,7 @@ export default function Music() {
 
       <main className="pt-16">
         <section className="flex" id="all-projects">
-          <motion.div
+          <Motion.div
             initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 1 }}
@@ -77,12 +75,12 @@ export default function Music() {
                 ))}
               </div>
             </div>
-          </motion.div>
+          </Motion.div>
         </section>
 
         {/* Project section */}
         <section className="flex min-h-auto flex-col items-center justify-center bg-gray-50">
-          <motion.div
+          <Motion.div
             className="flex w-full flex-col items-center"
             initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
@@ -91,14 +89,20 @@ export default function Music() {
             <div className="mx-auto mt-3 mr-3 mb-3 ml-3 grid border-collapse grid-cols-1 gap-3 sm:grid-cols-3 lg:grid-cols-3">
               <AnimatePresence mode="wait">
                 {filteredProjects.map((project) => (
-                  <motion.div
+                  <Motion.div
                     key={`${project.title}-${activeFilter}`} // Use a unique key
                     initial={{ opacity: 0, y: 10 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.7 }}
                   >
-                    <MusicCard link={project.link} />
-                  </motion.div>
+                    <MusicCard
+                      title={project.title}
+                      artist={project.description}
+                      image={project.image}
+                      link={project.link}
+                      date={project.date}
+                    />
+                  </Motion.div>
                 ))}
               </AnimatePresence>
             </div>
@@ -110,7 +114,7 @@ export default function Music() {
             >
               Back to Home
             </a>
-          </motion.div>
+          </Motion.div>
         </section>
       </main>
     </>

--- a/src/Projects.jsx
+++ b/src/Projects.jsx
@@ -1,5 +1,5 @@
 import Navbar from "./components/Navbar.jsx";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion as Motion, AnimatePresence } from "framer-motion";
 import ProjectCardv2 from "./components/ProjectCard-v2.jsx";
 import monopolyUrl from "/mini-monopoly.jpg";
 import strideUrl from "/stride.svg";
@@ -195,7 +195,7 @@ export default function Projects() {
 
       <main className="pt-16">
         <section className="flex">
-          <motion.div
+          <Motion.div
             initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 1 }}
@@ -222,12 +222,12 @@ export default function Projects() {
                 ))}
               </div>
             </div>
-          </motion.div>
+          </Motion.div>
         </section>
 
         {/* Project section */}
         <section className="flex min-h-auto flex-col items-center justify-center bg-gray-50">
-          <motion.div
+          <Motion.div
             className="flex w-full flex-col items-center"
             initial={{ opacity: 0, y: 40 }}
             animate={{ opacity: 1, y: 0 }}
@@ -236,7 +236,7 @@ export default function Projects() {
             <div className="mx-auto mt-3 mr-3 mb-3 ml-3 grid border-collapse grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-2">
               <AnimatePresence mode="wait">
                 {filteredProjects.map((project) => (
-                  <motion.div
+                  <Motion.div
                     key={`${project.title}-${activeFilter}`} // Use a unique key
                     initial={{ opacity: 0, y: 10 }}
                     animate={{ opacity: 1, y: 0 }}
@@ -249,7 +249,7 @@ export default function Projects() {
                       image={project.image}
                       skills={project.skills}
                     />
-                  </motion.div>
+                  </Motion.div>
                 ))}
               </AnimatePresence>
             </div>
@@ -261,7 +261,7 @@ export default function Projects() {
             >
               Back to Home
             </a>
-          </motion.div>
+          </Motion.div>
         </section>
       </main>
     </>


### PR DESCRIPTION
## Summary
- pass the right props to `MusicCard`
- rename motion imports to avoid lint errors
- drop unused image imports

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889d4028444832584db9f8d56fd8191